### PR TITLE
fix S. flexneri serotype prediction; update GHActions

### DIFF
--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -75,9 +75,9 @@ jobs:
       # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040580
       - name: Test ShigaTyper with a Shigella flexneri serotype 1b
         run: |
-          fastq-dl -a SRR8186703 
-          python3 -m shigatyper.shigatyper --R1 SRR8186703_1.fastq.gz --R2 SRR8186703_2.fastq.gz -n SRR8186703
-          grep 'serotype 1b' SRR8186703.tsv
+          fastq-dl -a SRR8186627 
+          python3 -m shigatyper.shigatyper --R1 SRR8186627_1.fastq.gz --R2 SRR8186627_2.fastq.gz -n SRR8186627
+          grep 'serotype 1b' SRR8186627.tsv
 
       # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040584
       - name: Test ShigaTyper with a Shigella flexneri serotype 2a
@@ -120,3 +120,17 @@ jobs:
           fastq-dl -a SRR1811686 
           python3 -m shigatyper.shigatyper --R1 SRR1811686_1.fastq.gz --R2 SRR1811686_2.fastq.gz -n SRR1811686
           grep 'serotype 5a' SRR1811686.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040648
+      - name: Test ShigaTyper with a Shigella flexneri serotype 6
+        run: |
+          fastq-dl -a SRR8186591 
+          python3 -m shigatyper.shigatyper --R1 SRR8186591_1.fastq.gz --R2 SRR8186591_2.fastq.gz -n SRR8186591
+          grep 'serotype 6' SRR8186591.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10052844
+      - name: Test ShigaTyper with a Shigella flexneri serotype 7b
+        run: |
+          fastq-dl -a SRR8186647
+          python3 -m shigatyper.shigatyper --R1 SRR8186647_1.fastq.gz --R2 SRR8186647_2.fastq.gz -n SRR8186647
+          grep 'serotype 7b' SRR8186647.tsv

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -29,8 +29,8 @@ jobs:
           channel-priority: true
           environment-file: environment.yaml
 
-      #- name: Setup ShigaTyper Environment
-      #  run: mamba install -y -c conda-forge -c bioconda bcftools fastq-dl minimap2 pandas pysam samtools
+      - name: add fastq-dl to existing env
+        run: mamba install -y -c conda-forge -c bioconda fastq-dl
 
       - name: Environment Information
         run: uname -a && env

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -27,9 +27,10 @@ jobs:
           mamba-version: "*"
           channels: conda-forge,bioconda,defaults
           channel-priority: true
+          environment-file: environment.yaml
 
-      - name: Setup ShigaTyper Environment
-        run: mamba install -y -c conda-forge -c bioconda bcftools fastq-dl minimap2 pandas pysam samtools
+      #- name: Setup ShigaTyper Environment
+      #  run: mamba install -y -c conda-forge -c bioconda bcftools fastq-dl minimap2 pandas pysam samtools
 
       - name: Environment Information
         run: uname -a && env
@@ -67,5 +68,5 @@ jobs:
       # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040641
       - name: Test ShigaTyper with a Shigella flexneri serotype 4a
         run: |
-          fastq-dl SRR8186703 
+          fastq-dl -a SRR8186703 
           python3 -m shigatyper.shigatyper --R1 SRR8186703_1.fastq.gz --R2 SRR8186703_2.fastq.gz -n SRX5006488

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -60,3 +60,10 @@ jobs:
         run: |
           cat SRX5006488_R1.fastq.gz SRX5006488_R2.fastq.gz > SRX5006488SE.fastq.gz
           python3 -m shigatyper.shigatyper --SE SRX5006488SE.fastq.gz -n SRX5006488
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040641
+      - name: Test ShigaTyper with a Shigella flexneri serotype 4a
+        run: |
+          fastq-dl SRR8186703 ENA 
+          cat SRX5006488_R1.fastq.gz SRX5006488_R2.fastq.gz > SRX5006488SE.fastq.gz
+          python3 -m shigatyper.shigatyper --R1 SRX5006488SE.fastq.gz -n SRX5006488

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test ShigaTyper with paired-end reads
         run: |
-          fastq-dl SRX5006488 ENA --is_experiment --group_by_experiment
+          fastq-dl -a SRX5006488 ENA --group-by-experiment
           python3 -m shigatyper.shigatyper --R1 SRX5006488_R1.fastq.gz --R2 SRX5006488_R2.fastq.gz
 
       - name: Test ShigaTyper with single-end reads
@@ -51,7 +51,7 @@ jobs:
 
       - name: Test ShigaTyper with ONT reads
         run: |
-          fastq-dl SRX7050861 ENA --is_experiment --group_by_experiment
+          fastq-dl -a SRX7050861 ENA --group-by-experiment
           python3 -m shigatyper.shigatyper --SE SRX7050861.fastq.gz --ont
 
       - name: Test ShigaTyper with non-Shigella reads
@@ -68,5 +68,4 @@ jobs:
       - name: Test ShigaTyper with a Shigella flexneri serotype 4a
         run: |
           fastq-dl SRR8186703 ENA 
-          cat SRX5006488_R1.fastq.gz SRX5006488_R2.fastq.gz > SRX5006488SE.fastq.gz
-          python3 -m shigatyper.shigatyper --R1 SRX5006488SE.fastq.gz -n SRX5006488
+          python3 -m shigatyper.shigatyper --R1 SRR8186703_1.fastq.gz --R2 SRR8186703_2.fastq.gz -n SRX5006488

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -107,7 +107,7 @@ jobs:
           python3 -m shigatyper.shigatyper --R1 SRR8186727_1.fastq.gz --R2 SRR8186727_2.fastq.gz -n SRR8186727
           grep 'serotype 3b' SRR8186727.tsv
 
-      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040641
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040581
       - name: Test ShigaTyper with a Shigella flexneri serotype Xv (4c)
         run: |
           fastq-dl -a SRR8186631 
@@ -115,11 +115,19 @@ jobs:
           grep 'serotype Xv (4c)' SRR8186631.tsv
 
       # BioSample: https://www.ncbi.nlm.nih.gov/biosample/SAMN03291463
+      # this sample was not in Shigatyper paper, I found it randomly on NCBI
       - name: Test ShigaTyper with a Shigella flexneri serotype 5a
         run: |
           fastq-dl -a SRR1811686 
           python3 -m shigatyper.shigatyper --R1 SRR1811686_1.fastq.gz --R2 SRR1811686_2.fastq.gz -n SRR1811686
           grep 'serotype 5a' SRR1811686.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10052842
+      - name: Test ShigaTyper with a Shigella flexneri serotype Y
+        run: |
+          fastq-dl -a SRR8186645
+          python3 -m shigatyper.shigatyper --R1 SRR8186645_1.fastq.gz --R2 SRR8186645_2.fastq.gz -n SRR8186645
+          grep 'serotype Y' SRR8186645.tsv
 
       # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040648
       - name: Test ShigaTyper with a Shigella flexneri serotype 6
@@ -127,6 +135,13 @@ jobs:
           fastq-dl -a SRR8186591 
           python3 -m shigatyper.shigatyper --R1 SRR8186591_1.fastq.gz --R2 SRR8186591_2.fastq.gz -n SRR8186591
           grep 'serotype 6' SRR8186591.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040589
+      - name: Test ShigaTyper with a Shigella flexneri serotype 1c (7a)
+        run: |
+          fastq-dl -a SRR8186684
+          python3 -m shigatyper.shigatyper --R1 SRR8186684_1.fastq.gz --R2 SRR8186684_2.fastq.gz -n SRR8186684
+          grep 'serotype 1c (7a)' SRR8186684.tsv
 
       # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10052844
       - name: Test ShigaTyper with a Shigella flexneri serotype 7b

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -29,8 +29,8 @@ jobs:
           channel-priority: true
           environment-file: environment.yaml
 
-      - name: add fastq-dl to existing env
-        run: mamba install -y -c conda-forge -c bioconda fastq-dl
+      - name: add fastq-dl to existing mamba env
+        run: mamba install -y -c conda-forge -c bioconda 'fastq-dl>=2.0.1'
 
       - name: Environment Information
         run: uname -a && env
@@ -65,8 +65,58 @@ jobs:
           cat SRX5006488_R1.fastq.gz SRX5006488_R2.fastq.gz > SRX5006488SE.fastq.gz
           python3 -m shigatyper.shigatyper --SE SRX5006488SE.fastq.gz -n SRX5006488
 
-      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040641
-      - name: Test ShigaTyper with a Shigella flexneri serotype 4a
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10052838
+      - name: Test ShigaTyper with a Shigella flexneri serotype 1a
+        run: |
+          fastq-dl -a SRR8186648 
+          python3 -m shigatyper.shigatyper --R1 SRR8186648_1.fastq.gz --R2 SRR8186648_2.fastq.gz -n SRR8186648
+          grep 'serotype 1a' SRR8186648.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040580
+      - name: Test ShigaTyper with a Shigella flexneri serotype 1b
         run: |
           fastq-dl -a SRR8186703 
-          python3 -m shigatyper.shigatyper --R1 SRR8186703_1.fastq.gz --R2 SRR8186703_2.fastq.gz -n SRX5006488
+          python3 -m shigatyper.shigatyper --R1 SRR8186703_1.fastq.gz --R2 SRR8186703_2.fastq.gz -n SRR8186703
+          grep 'serotype 1b' SRR8186703.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040584
+      - name: Test ShigaTyper with a Shigella flexneri serotype 2a
+        run: |
+          fastq-dl -a SRR8186705 
+          python3 -m shigatyper.shigatyper --R1 SRR8186705_1.fastq.gz --R2 SRR8186705_2.fastq.gz -n SRR8186705
+          grep 'serotype 2a' SRR8186705.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040583
+      - name: Test ShigaTyper with a Shigella flexneri serotype 2b
+        run: |
+          fastq-dl -a SRR8186704 
+          python3 -m shigatyper.shigatyper --R1 SRR8186704_1.fastq.gz --R2 SRR8186704_2.fastq.gz -n SRR8186704
+          grep 'serotype 2b' SRR8186704.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10052840
+      - name: Test ShigaTyper with a Shigella flexneri serotype 3a
+        run: |
+          fastq-dl -a SRR8186651 
+          python3 -m shigatyper.shigatyper --R1 SRR8186651_1.fastq.gz --R2 SRR8186651_2.fastq.gz -n SRR8186651
+          grep 'serotype 3a' SRR8186651.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040645
+      - name: Test ShigaTyper with a Shigella flexneri serotype 3b
+        run: |
+          fastq-dl -a SRR8186727 
+          python3 -m shigatyper.shigatyper --R1 SRR8186727_1.fastq.gz --R2 SRR8186727_2.fastq.gz -n SRR8186727
+          grep 'serotype 3b' SRR8186727.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040641
+      - name: Test ShigaTyper with a Shigella flexneri serotype Xv (4c)
+        run: |
+          fastq-dl -a SRR8186631 
+          python3 -m shigatyper.shigatyper --R1 SRR8186631_1.fastq.gz --R2 SRR8186631_2.fastq.gz -n SRR8186631
+          grep 'serotype Xv (4c)' SRR8186631.tsv
+
+      # BioSample: https://www.ncbi.nlm.nih.gov/biosample/SAMN03291463
+      - name: Test ShigaTyper with a Shigella flexneri serotype 5a
+        run: |
+          fastq-dl -a SRR1811686 
+          python3 -m shigatyper.shigatyper --R1 SRR1811686_1.fastq.gz --R2 SRR1811686_2.fastq.gz -n SRR1811686
+          grep 'serotype 5a' SRR1811686.tsv

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -19,14 +19,17 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Setup miniconda
+      - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: shigatyper
           auto-activate-base: false
+          mamba-version: "*"
+          channels: conda-forge,bioconda,defaults
+          channel-priority: true
 
       - name: Setup ShigaTyper Environment
-        run: conda install -y -c conda-forge -c bioconda bcftools fastq-dl minimap2 pandas pysam samtools
+        run: mamba install -y -c conda-forge -c bioconda bcftools fastq-dl minimap2 pandas pysam samtools
 
       - name: Environment Information
         run: uname -a && env

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test-shigatyper.yml
+++ b/.github/workflows/test-shigatyper.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test ShigaTyper with paired-end reads
         run: |
-          fastq-dl -a SRX5006488 ENA --group-by-experiment
+          fastq-dl -a SRX5006488 --group-by-experiment
           python3 -m shigatyper.shigatyper --R1 SRX5006488_R1.fastq.gz --R2 SRX5006488_R2.fastq.gz
 
       - name: Test ShigaTyper with single-end reads
@@ -51,7 +51,7 @@ jobs:
 
       - name: Test ShigaTyper with ONT reads
         run: |
-          fastq-dl -a SRX7050861 ENA --group-by-experiment
+          fastq-dl -a SRX7050861 --group-by-experiment
           python3 -m shigatyper.shigatyper --SE SRX7050861.fastq.gz --ont
 
       - name: Test ShigaTyper with non-Shigella reads
@@ -67,5 +67,5 @@ jobs:
       # BioSample: https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN10040641
       - name: Test ShigaTyper with a Shigella flexneri serotype 4a
         run: |
-          fastq-dl SRR8186703 ENA 
+          fastq-dl SRR8186703 
           python3 -m shigatyper.shigatyper --R1 SRR8186703_1.fastq.gz --R2 SRR8186703_2.fastq.gz -n SRX5006488

--- a/shigatyper/shigatyper.py
+++ b/shigatyper/shigatyper.py
@@ -447,9 +447,9 @@ def run(reads, tempdir, sample_name='', threshold=50, rlog=rlog, ont=False, outd
                     elif wzx == "Sf6_wzx":
                         prediction = "Shigella flexneri serotype 6"
                     elif wzx == "Sf_wzx":
-                        Hits.remove("Sf_wzx")
-                    else:
                         try: Hits.remove("Sf_wzy")
+                        except: Hits = Hits
+                        try: Hits.remove("Sf_wzx")
                         except: Hits = Hits
                         if len(Hits) == 0:
                             prediction = "Shigella flexneri serotype Y"
@@ -474,6 +474,8 @@ def run(reads, tempdir, sample_name='', threshold=50, rlog=rlog, ont=False, outd
                                     prediction = Serotype; predict += 1
                             if predict == 0:
                                 prediction = "Shigella flexneri, novel serotype"
+                    else:
+                        prediction = "Unable to determine a serotype based on gene hits"
         lapse = datetime.datetime.now() - start
         log.info(f"Complete in {readable(lapse)}.")
         timetrack.append(lapse.total_seconds())


### PR DESCRIPTION
Here's my attempt to fix issue #11 regarding S. flexneri serotype prediction.

This PR definitely needs some review here as I'm not a python expert and I'm also not an expert in Shigella serotype prediction and the logic to do so.

I've tweaked the `shigatyper/shigatyper.py` which seems to have restored the ability to predict serotypes for S. flexneri. I adjusted the if/elif/else conditionals so that if `wzx` is equal to `Sf_wzx` (meaning the sample contains the flexneri wzx gene), then remove both `Sf_wzx` and `Sf_wzy` from `Hits` and continue on to S. flexneri serotype prediction.

The `else` statement now occurs for samples where the `wzx` hit does not match any known genes and the `prediction` is set as: `prediction = "Unable to determine a serotype based on gene hits"` **This one may need to be changed prior to merging.**

To show that these changes work as expected, I've made a few changes to the GitHub Actions workflow to test a number of different Shigella flexneri Serotypes. I pulled almost all of the SRR accessions from the Shigatyper paper Supplemental table S1, and thus should be good data to test with.

Changes to `.github/workflows/test-shigatyper.yml`:

- upgraded to `actions/checkout@v3` to remove node.js warning
- installing some deps via `mamba` instead of conda since it's faster
  - installing deps via the included `environment.yml` file instead of manually with `mamba install <dep>`
  - fastq-dl pinned to 2.0.1 or higher
- altered `fastq-dl` commands to match new v2 command syntax
- added tests for numerous Shigella flexneri serotypes

Feedback of course welcome, hope this helps resolve the issue!